### PR TITLE
MULTISITE-18536 - Fix declaration of Symlink method

### DIFF
--- a/includes/phing/src/Tasks/SymlinkPropertyContentTask.php
+++ b/includes/phing/src/Tasks/SymlinkPropertyContentTask.php
@@ -301,14 +301,14 @@ class SymlinkPropertyContentTask extends RelativeSymlinkTask
      *
      * @param string $targetPath Target of symlink
      * @param string $link       Symlink
+     * @param bool   $logShort   Log short
      *
      * @return void
      */
-    protected function symlink($targetPath, $link)
+    protected function symlink($targetPath, $link, $logShort = false)
     {
-        parent::symlink($targetPath, $link);
+        parent::symlink($targetPath, $link, $logShort);
     }//end symlink()
-
 
     /**
      * Create a directory


### PR DESCRIPTION
```
[PHP Error] Declaration of Phing\Toolkit\Tasks\SymlinkPropertyContentTask::symlink($targetPath, $link) should be compatible with Phing\Toolkit\Tasks\RelativeSymlinkTask::symlink($target, $link, $logShort = false) [line 383 of /Users/joaosantos/Sites/EuropeanComission/Tickets/MULTISITE-18318/vendor/ec-europa/toolkit/includes/phing/src/Tasks/SymlinkPropertyContentTask.php]
```